### PR TITLE
Patch filename fix

### DIFF
--- a/patch-autopkg.sh
+++ b/patch-autopkg.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu 
+set -eu
 # This script installs and patches autopkg 2.2 with unreleased changes needed to work with the SimpleMDM Repo Plugin
 # The changes are derived from this commit:
 # https://github.com/autopkg/autopkg/commit/af858c033643089b8ecbccf0a8ad691d4c28a289
@@ -25,7 +25,6 @@ git clone https://github.com/autopkg/autopkg.git "$autopkg_repo_path"
 cp -v "${autopkg_repo_path}/Code/autopkglib/MunkiImporter.py" /Library/AutoPkg/autopkglib/MunkiImporter.py
 cp -v "${autopkg_repo_path}/Code/autopkglib/munkirepolibs/AutoPkgLib.py" /Library/AutoPkg/autopkglib/munkirepolibs/AutoPkgLib.py
 cp -v "${autopkg_repo_path}/Code/autopkglib/munkirepolibs/AutoPkgLib.py" /Library/AutoPkg/autopkglib/munkirepolibs/AutoPkgLib.py
-# this one is renamed MunkiLibAdapter.py
-cp -v "${autopkg_repo_path}/Code/autopkglib/munkirepolibs/MunkiLib.py" /Library/AutoPkg/autopkglib/munkirepolibs/MunkiLibAdapter.py
+cp -v "${autopkg_repo_path}/Code/autopkglib/munkirepolibs/MunkiLib.py" /Library/AutoPkg/autopkglib/munkirepolibs/MunkiLib.py
 
 rm -rf "$autopkg_repo_path"


### PR DESCRIPTION
The patched codebase is looking for MunkiLib.py and not MunkiLibAdapter.py, so one of the ```cp``` commands in the last patch was incorrect 